### PR TITLE
Added progress bar when downloading records    

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "2.7"
 
-install: pip install coveralls biopython
+install: pip install -r requirements.txt
 
 script: nosetests tests/ --with-coverage --cover-package=genbank
 

--- a/genbank.py
+++ b/genbank.py
@@ -319,7 +319,7 @@ def downloadRecords(idList, destDir, batchSize, delay = 30,
     # Download the batches
     bar = pyprind.ProgBar(len(newIdList) / batchSize, monitor=True,
                           title='Downloading the batches')
-    for i in range(0, len(newIdList), batchSize) :
+    for i in range(0, len(newIdList), batchSize):
         end = min(len(newIdList), i + batchSize)
         batch = newIdList[i: end]
         _downloadBatch(batch, destDir, downloadFullWGS)

--- a/genbank.py
+++ b/genbank.py
@@ -26,8 +26,10 @@ import StringIO
 import hashlib
 import urllib2
 import gzip
+
 from Bio import Entrez
 from Bio import SeqIO
+import pyprind
 
 ### ** Default variables
 
@@ -313,12 +315,16 @@ def downloadRecords(idList, destDir, batchSize, delay = 30,
         newIdList = idList
     else :
         newIdList = [x for x in idList if not ((x + ".gb") in existingFileList)]
+
     # Download the batches
+    bar = pyprind.ProgBar(len(newIdList) / batchSize, monitor=True,
+                          title='Downloading the batches')
     for i in range(0, len(newIdList), batchSize) :
         end = min(len(newIdList), i + batchSize)
         batch = newIdList[i: end]
         _downloadBatch(batch, destDir, downloadFullWGS)
         time.sleep(delay)
+        bar.update()
 
 ### *** _downloadBatch(idBatch, destDir, downloadFullWGS = False)
 
@@ -347,7 +353,7 @@ def _downloadBatch(idBatch, destDir, downloadFullWGS = False) :
     r = _getRecordBatch(idBatch)
     # Split the downloaded strings into records
     r = r.strip().split("\n//")
-    print(r)
+    # print(r)
     assert r[-1] == ""
     r = r[0: -1]
     assert len(r) == len(idBatch)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 biopython==1.65
+psutil==2.2.1
+Pyprind==2.9.2
 sphinxcontrib-napoleon==0.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 biopython==1.65
+coveralls==0.5
 psutil==2.2.1
 Pyprind==2.9.2
 sphinxcontrib-napoleon==0.3.7


### PR DESCRIPTION
A progress bar will appear then the downloading starts and will update itself
as the items get downloaded. It also shows the estimated time that it will take
to finish. It does not appear too acurate now, might be due to the `sleep`
command in line 326.

It requires two additional libraries `pyprind` and `psutil`.
